### PR TITLE
Fix bug where mixed-case query parameters prevents matching

### DIFF
--- a/src/util/normalize-url.ts
+++ b/src/util/normalize-url.ts
@@ -8,6 +8,6 @@ export default function normalize(url: string): string {
     return normalizeUrl(url, {
         stripWWW: false,
         removeTrailingSlash: false,
-        removeQueryParameters: [/.*/g],
+        removeQueryParameters: [/.*/],
     });
 }

--- a/test/integration/matchers/query-matching.spec.ts
+++ b/test/integration/matchers/query-matching.spec.ts
@@ -38,4 +38,12 @@ describe("Request query matching", function () {
 
         await expect(result).to.have.status(503);
     });
+
+    it("should match with mixed-case query parameters", async () => {
+        await server.get('/').withQuery({ c: "hello" }).thenReply(200);
+
+        let result = await fetch(server.urlFor('/?aB=&c=hello'));
+
+        await expect(result).to.have.status(200);
+    });
 });


### PR DESCRIPTION
Using the global flag triggers [this behavior](https://stackoverflow.com/a/1520853/168581) which causes incorrect matches. I'm not sure why this *seems* to only be an issue with mixed case query parameters.