### PR TITLE
Add matcher for cookies

### DIFF
--- a/src/rules/matchers.ts
+++ b/src/rules/matchers.ts
@@ -176,7 +176,7 @@ export class CookieMatcherData extends Serializable {
                 const cookies = request.headers.cookie.split(';').map(cookie => {
                     const [key, value] = cookie.split('=');
 
-                    return {[key.trim()]: value.trim()}
+                    return { [key.trim()]: (value || '').trim()}
                 });
 
                 return cookies.some(element => _.isEqual(element, this.cookie))

--- a/src/rules/mock-rule-builder.ts
+++ b/src/rules/mock-rule-builder.ts
@@ -32,7 +32,8 @@ import {
     QueryMatcherData,
     FormDataMatcherData,
     RawBodyMatcherData,
-    WildcardMatcherData
+    WildcardMatcherData,
+    CookieMatcherData
 } from "./matchers";
 
 import {
@@ -130,6 +131,14 @@ export default class MockRuleBuilder {
      */
     withBody(content: string): MockRuleBuilder {
         this.matchers.push(new RawBodyMatcherData(content));
+        return this;
+    }
+
+    /**
+     * Match only requests that include the given cookies
+     */
+    withCookie(cookie: { [key: string]: string }) {
+        this.matchers.push(new CookieMatcherData(cookie));
         return this;
     }
 

--- a/test/integration/matchers/cookie-matching.spec.ts
+++ b/test/integration/matchers/cookie-matching.spec.ts
@@ -16,33 +16,20 @@ nodeOnly(() => {
         });
 
         it("should match requests with the matching cookie", async () => {
-            let response: any = {};
-            let status: any = null;
             const requestCookie = request.cookie('supercookie=yummi');
             const cookiejar = request.jar();
 
             cookiejar.setCookie(requestCookie, server.url);
 
-            const options = {
+            const response = await request({
                 uri: server.url,
-                jar: cookiejar,
-                resolveWithFullResponse: true,
-                simple: false,
-            };
+                jar: cookiejar
+            });
 
-
-            await request(options)
-                .then((resp) => {
-                    response = resp.body;
-                    status = resp.statusCode;
-                });
-
-            expect(await response).to.equal("matched cookie");
+            expect(response).to.equal("matched cookie");
         });
 
         it("should match requests with the matching cookie when multiple cookies are present", async () => {
-            let response: any = {};
-            let status: any = null;
             const matchingCookie = request.cookie('supercookie=yummi');
             const notMatchingCookie = request.cookie('megacookie=delicious');
             const cookiejar = request.jar();
@@ -50,63 +37,38 @@ nodeOnly(() => {
             cookiejar.setCookie(matchingCookie, server.url);
             cookiejar.setCookie(notMatchingCookie, server.url);
 
-            const options = {
+            const response = await request({
                 uri: server.url,
-                jar: cookiejar,
-                resolveWithFullResponse: true,
-                simple: false,
-            };
+                jar: cookiejar
+            });
 
-
-            await request(options)
-                .then((resp) => {
-                    response = resp.body;
-                    status = resp.statusCode;
-                });
-
-            expect(await response).to.equal("matched cookie");
+            expect(response).to.equal("matched cookie");
         });
 
         it("should not match requests when cookie has a different value", async () => {
-            let response: any = {};
-            let status: any = null;
             const requestCookie = request.cookie('megacookie=delicious; supercookie=delicious');
             const cookiejar = request.jar();
 
             cookiejar.setCookie(requestCookie, server.url);
 
-            const options = {
+            const { statusCode } = await request({
                 uri: server.url,
                 jar: cookiejar,
                 resolveWithFullResponse: true,
-                simple: false,
-            };
+                simple: false
+            })
 
-            await request(options)
-                .then((resp) => {
-                    response = resp.body;
-                    status = resp.statusCode;
-                });
-
-            expect(status).to.equal(503);
+            expect(statusCode).to.equal(503);
         });
 
         it("should not match requests when no cookies are present", async () => {
-            let response: any = {};
-            let status: any = null;
-            const options = {
+            const { statusCode } = await request({
                 uri: server.url,
                 resolveWithFullResponse: true,
-                simple: false,
-            };
+                simple: false
+            })
 
-            await request(options)
-                .then((resp) => {
-                    response = resp.body;
-                    status = resp.statusCode;
-                });
-
-            expect(status).to.equal(503);
+            expect(statusCode).to.equal(503);
         });
     });
 });

--- a/test/integration/matchers/cookie-matching.spec.ts
+++ b/test/integration/matchers/cookie-matching.spec.ts
@@ -1,0 +1,112 @@
+import { getLocal } from "../../..";
+import {expect, fetch, Headers, nodeOnly} from "../../test-utils";
+import * as request from 'request-promise-native';
+
+nodeOnly(() => {
+    describe("Cookie matching", function () {
+        let server = getLocal();
+
+        beforeEach(() => server.start());
+        afterEach(() => server.stop());
+
+        beforeEach(() => {
+            server.get("/")
+                .withCookie({"supercookie": "yummi"})
+                .thenReply(200, "matched cookie");
+        });
+
+        it("should match requests with the matching cookie", async () => {
+            let response: any = {};
+            let status: any = null;
+            const requestCookie = request.cookie('supercookie=yummi');
+            const cookiejar = request.jar();
+
+            cookiejar.setCookie(requestCookie, server.url);
+
+            const options = {
+                uri: server.url,
+                jar: cookiejar,
+                resolveWithFullResponse: true,
+                simple: false,
+            };
+
+
+            await request(options)
+                .then((resp) => {
+                    response = resp.body;
+                    status = resp.statusCode;
+                });
+
+            expect(await response).to.equal("matched cookie");
+        });
+
+        it("should match requests with the matching cookie when multiple cookies are present", async () => {
+            let response: any = {};
+            let status: any = null;
+            const matchingCookie = request.cookie('supercookie=yummi');
+            const notMatchingCookie = request.cookie('megacookie=delicious');
+            const cookiejar = request.jar();
+
+            cookiejar.setCookie(matchingCookie, server.url);
+            cookiejar.setCookie(notMatchingCookie, server.url);
+
+            const options = {
+                uri: server.url,
+                jar: cookiejar,
+                resolveWithFullResponse: true,
+                simple: false,
+            };
+
+
+            await request(options)
+                .then((resp) => {
+                    response = resp.body;
+                    status = resp.statusCode;
+                });
+
+            expect(await response).to.equal("matched cookie");
+        });
+
+        it("should not match requests when cookie has a different value", async () => {
+            let response: any = {};
+            let status: any = null;
+            const requestCookie = request.cookie('megacookie=delicious; supercookie=delicious');
+            const cookiejar = request.jar();
+
+            cookiejar.setCookie(requestCookie, server.url);
+
+            const options = {
+                uri: server.url,
+                jar: cookiejar,
+                resolveWithFullResponse: true,
+                simple: false,
+            };
+
+            await request(options)
+                .then((resp) => {
+                    response = resp.body;
+                    status = resp.statusCode;
+                });
+
+            expect(status).to.equal(503);
+        });
+
+        it("should not match requests when no cookies are present", async () => {
+            let response: any = {};
+            let status: any = null;
+            const options = {
+                uri: server.url,
+                resolveWithFullResponse: true,
+                simple: false,
+            };
+
+            await request(options)
+                .then((resp) => {
+                    response = resp.body;
+                    status = resp.statusCode;
+                });
+
+            expect(status).to.equal(503);
+        });
+    });
+});


### PR DESCRIPTION
Extend the set of matches with a new one for cookies. Currently it is not possible to match for exactly one cookie if the header of the request contains more then one cookie. This new matcher should solve the problem. 