### PR TITLE
Allow clients to use the already used port on a standalone server

### DIFF
--- a/src/client/mockttp-client.ts
+++ b/src/client/mockttp-client.ts
@@ -166,7 +166,7 @@ export default class MockttpClient extends AbstractMockttp implements Mockttp {
     }
 
     async start(port?: number): Promise<void> {
-        if (this.mockServerConfig) throw new Error('Server is already started');
+        if (this.mockServerConfig && !this.mockServerOptions.allowMultiClientsOnPort) throw new Error('Server is already started');
 
         const path = port ? `/start?port=${port}` : '/start';
         let mockServerConfig = await this.requestFromStandalone<MockServerConfig>(path, {

--- a/src/mockttp.ts
+++ b/src/mockttp.ts
@@ -167,6 +167,7 @@ export interface Mockttp {
 }
 
 export interface MockttpOptions {
+    allowMultiClientsOnPort?: boolean;
     cors?: boolean;
     debug?: boolean;
     https?: CAOptions;


### PR DESCRIPTION
For test setups where you are not able to change the request url of the application that uses the mock server. 
With this changes you are able to instance a client for a standalone server when the port is already used by another client.  