### PR TITLE
feat: added unmatchedRequestHandler

### DIFF
--- a/src/server/mockttp-server.ts
+++ b/src/server/mockttp-server.ts
@@ -405,7 +405,10 @@ export default class MockttpServer extends AbstractMockttp implements Mockttp {
                 if (this.debug) console.log(`Request matched rule: ${nextRule.explain()}`);
                 await nextRule.handle(request, response, this.recordTraffic);
             } else {
-                await this.sendUnmatchedRequestError(request, response);
+                if (this.unmatchedRequestHandler)
+                    await this.unmatchedRequestHandler(request, response)
+                else
+                    await this.defaultUnmatchedRequestError(request, response);
             }
             result = result || 'responded';
         } catch (e) {
@@ -448,7 +451,7 @@ export default class MockttpServer extends AbstractMockttp implements Mockttp {
         }
     }
 
-    private async sendUnmatchedRequestError(request: OngoingRequest, response: http.ServerResponse) {
+    private async defaultUnmatchedRequestError(request: OngoingRequest, response: http.ServerResponse) {
         let requestExplanation = await this.explainRequest(request);
         if (this.debug) console.warn(`Unmatched request received: ${requestExplanation}`);
 


### PR DESCRIPTION
Background: Our use case is that we want to use `mockttp` for doing a man-in-the-middle of iOS and Android end-to-end tests. By that we configured the proxy on their ends and want to proxy all not-configured routes to the original backend server (actually serves only assets).