### PR TITLE
deps: upgrade graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "express": "^4.14.0",
     "express-graphql": "^0.11.0",
     "fetch-ponyfill": "^7.1.0",
-    "graphql": "^14.0.2",
+    "graphql": "^14.0.2 || ^15.5",
     "graphql-subscriptions": "^1.1.0",
     "http-encoding": "^1.4.0",
     "http2-wrapper": "2.0.5",


### PR DESCRIPTION
In NPM 7, dependency resolution behavior changes and can break builds. For our project, our dependencies are largely looking for graphql 15. Currently dependency resolution breaks for us with NPM 7 when using mockttp. The `--legacy-peer-deps` flag is a work-around, though we'd like to have all our graphql dependencies resolve to 15.x.  Upgrading to allow graphql 15.x will allow NPM 7 to resolve dependencies as expected.

I ran the tests with `npm run test`, and they all pass with `├── graphql@15.5.1` installed as far as I can see. I opted to allow either 14.x or 15.x to preserve any existing dependencies.

Is there anything else I should test, or anything else you'd like me to look at? I tested that the package installs locally under node 12/NPM 6 (latest), and node 16/NPM 7 (latest). Happy to discuss further, retarget a different base/ref, or do further testing/investigation as needed.