### PR TITLE
chore(deps): bump @types/express

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@httptoolkit/httpolyglot": "^1.0.0",
     "@httptoolkit/subscriptions-transport-ws": "^0.9.19",
     "@types/cors": "^2.8.6",
-    "@types/express": "^4.0.33",
+    "@types/express": "^4.17.13",
     "@types/node": "^14.14.37",
     "@types/node-forge": "^0.9.1",
     "base64-arraybuffer": "^0.1.5",


### PR DESCRIPTION
First of all, thanks for making this awesome library!

---

PR updates 4 year old `@types/express` dependency.

This older `@types/express` conflicts with newer versions of `@types/express` in a project.

Long thread describing the conflict:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49595#issuecomment-822923687

Some considerations to avoid dependency conflicts:
- If `@types/express` is only used during development it's probably better to declare it in `devDependencies`
- Or consider to use `*` as version, so transitive dependencies of `@types/express` won't conflict