### PR TITLE
Fix new years certificate instant expiry

### DIFF
--- a/src/util/tls.ts
+++ b/src/util/tls.ts
@@ -165,7 +165,7 @@ export class CA {
 
         cert.validity.notAfter = new Date();
         // Valid for the next year by default. TODO: Shorten (and expire the cache) automatically.
-        cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+        cert.validity.notAfter.setFullYear(cert.validity.notAfter.getFullYear() + 1);
 
         cert.setSubject([
             { name: 'commonName', value: domain },


### PR DESCRIPTION
When generating a client certificate, the script would reference the already mutated `notBefore` date, which resulted in the generation of a script with instant expiry for one day, on new years every year.

This references the `notAfter` date and generates a certificate with expiry for next year.