### PR TITLE
Draft implementation of server.on(handle-error, ...)

### DIFF
--- a/src/client/mockttp-admin-request-builder.ts
+++ b/src/client/mockttp-admin-request-builder.ts
@@ -303,6 +303,44 @@ export class MockttpAdminRequestBuilder {
                         body
                     }
                 }
+            }`,
+            // TODO: This is just a copy of the previous client-error section. Needs to be finished.
+            'handle-error': gql`subscription OnError {
+                failedRequest {
+                    errorCode
+                    request {
+                        id
+                        timingEvents
+                        tags
+                        protocol
+                        httpVersion
+                        method
+                        url
+                        path
+
+                        ${this.schema.typeHasField('ClientErrorRequest', 'rawHeaders')
+                            ? 'rawHeaders'
+                            : 'headers'
+                        }
+
+                        ${this.schema.asOptionalField('ClientErrorRequest', 'remoteIpAddress')},
+                        ${this.schema.asOptionalField('ClientErrorRequest', 'remotePort')},
+                    }
+                    response {
+                        id
+                        timingEvents
+                        tags
+                        statusCode
+                        statusMessage
+
+                        ${this.schema.typeHasField('Response', 'rawHeaders')
+                            ? 'rawHeaders'
+                            : 'headers'
+                        }
+
+                        body
+                    }
+                }
             }`
         }[event];
 

--- a/src/mockttp.ts
+++ b/src/mockttp.ts
@@ -416,6 +416,23 @@ export interface Mockttp {
     on(event: 'client-error', callback: (error: ClientError) => void): Promise<void>;
 
     /**
+     * Subscribe to hear about requests that fail before successfully sending their
+     * initial parameters (the request line & headers). This will fire for requests
+     * that drop connections early, send invalid or too-long headers, or aren't
+     * correctly parseable in some form.
+     *
+     * This is only useful in some niche use cases, such as logging all requests
+     * seen by the server, independently of the rules defined.
+     *
+     * The callback will be called asynchronously from request handling. This function
+     * returns a promise, and the callback is not guaranteed to be registered until
+     * the promise is resolved.
+     *
+     * @category Events
+     */
+    on(event: 'handle-error', callback: (error: ClientError) => void): Promise<void>;
+
+    /**
      * Adds the given rules to the server.
      *
      * This API is only useful if you're manually building rules, rather than
@@ -576,7 +593,8 @@ export type SubscribableEvent =
     | 'response'
     | 'abort'
     | 'tls-client-error'
-    | 'client-error';
+    | 'client-error'
+    | 'handle-error';
 
 /**
  * @hidden


### PR DESCRIPTION
It's a follow-up of this ticket: https://github.com/httptoolkit/mockttp/issues/78

Now it should be possible to hide errors for example:
```ts
  // Hide other errors
  server.on('handle-error', () => {});
```

Still needs works.
