### PR TITLE
Upgrade TypeScript target to `ES2020`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,13 @@
 {
     "compilerOptions": {
-        "target": "es6",
+        "target": "ES2020",
         "module": "commonjs",
         "outDir": "./dist",
         "declaration": true,
         "sourceMap": true,
         "strict": true,
         "lib": [
-            "dom",
-            "es2015",
-            "scripthost"
+            "ES2020",
         ],
         "paths": {
             "https-proxy-agent": ["./custom-typings/proxy-agent-modules.d.ts"],


### PR DESCRIPTION
This PR upgrades the TypeScript target to `ES2020` which is the TypeScript [recommended version](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-14) for Node 14.
Closes https://github.com/httptoolkit/mockttp/issues/114.

**Note:** This might be considered as a breaking change even if mockttp explicitly requires Node >= 14.