### PR TITLE
Properly close upstream connection on client abort

### DIFF
--- a/src/rules/requests/request-handlers.ts
+++ b/src/rules/requests/request-handlers.ts
@@ -963,20 +963,17 @@ export class PassThroughHandler extends PassThroughHandlerDefinition {
 
             // If the downstream connection aborts, before the response has been completed,
             // we also abort the upstream connection. Important to avoid unnecessary connections,
-            // and to correctly proxy client connection behavior to the upstream server.
+            // and to correctly proxy client connection behaviour to the upstream server.
             function abortUpstream() {
                 serverReq.abort();
             }
 
-            // Handle the case where the downstream connection is prematurely closes before 
-            // finishing sending the request.
+            // Handle the case where the downstream connection is prematurely closed before
+            // fully sending the request or receiving the response.
             clientReq.on('aborted', abortUpstream);
-
-            // Handle the case where the downstream connection is prematurely closed before 
-            // receiving the entire response.
             clientRes.on('close', abortUpstream);
 
-            // Cleanup the upstream request abort handler once the response has been sent.
+            // Disable the upstream request abort handlers once the response has been received.
             clientRes.once('finish', () => {
                 clientReq.off('aborted', abortUpstream);
                 clientRes.off('close', abortUpstream);

--- a/test/integration/subscriptions/response-events.spec.ts
+++ b/test/integration/subscriptions/response-events.spec.ts
@@ -4,7 +4,6 @@ import * as zlib from 'zlib';
 
 import {
     getLocal,
-    InitiatedRequest,
     CompletedRequest,
     CompletedResponse,
     Mockttp,
@@ -17,28 +16,9 @@ import {
     nodeOnly,
     isNode,
     getDeferred,
-    delay
+    delay,
+    makeAbortableRequest
 } from "../../test-utils";
-
-function makeAbortableRequest(server: Mockttp, path: string) {
-    if (isNode) {
-        let req = http.request({
-            method: 'POST',
-            hostname: 'localhost',
-            port: server.port,
-            path
-        });
-        req.on('error', () => {});
-        return req;
-    } else {
-        let abortController = new AbortController();
-        fetch(server.urlFor(path), {
-            method: 'POST',
-            signal: abortController.signal as AbortSignal
-        }).catch(() => {});
-        return abortController;
-    }
-}
 
 describe("Response subscriptions", () => {
 
@@ -428,38 +408,6 @@ describe("Abort subscriptions", () => {
             expect(seenAbort.timingEvents.bodyReceivedTimestamp).to.equal(undefined);
             expect(seenAbort.error).to.equal(undefined); // Client abort, not an error
             expect(wasRequestSeen).to.equal(false);
-        });
-
-        describe('given client abort the request', () => {
-            const remoteServer = getLocal();
-
-            beforeEach(() => remoteServer.start());
-            afterEach(() => remoteServer.stop());
-
-            it('should abort upstream request', async () => {
-                const seenRequestPromise = getDeferred<CompletedRequest>();
-                remoteServer.on('request', (r) => seenRequestPromise.resolve(r));
-    
-                const seenAbortPromise = getDeferred<AbortedRequest>();
-                remoteServer.on('abort', (r) => seenAbortPromise.resolve(r));
-                
-                await remoteServer.forPost('/mocked-endpoint').thenTimeout();
-    
-                await server.forPost('/mocked-endpoint').thenPassThrough();
-    
-                const abortableRequest = makeAbortableRequest(
-                    server, 
-                    remoteServer.urlFor('/mocked-endpoint')
-                ) as http.ClientRequest;
-                abortableRequest.end();
-    
-                const seenRequest = await seenRequestPromise;
-                abortableRequest.abort();
-    
-                const seenAbort = await seenAbortPromise;
-                expect(seenRequest.id).to.equal(seenAbort.id);
-                expect(seenAbort.error).to.equal(undefined); // Client abort, not an error
-            });
         });
 
         describe("given a server that closes connections", () => {

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -178,6 +178,26 @@ export async function writeAndReset(socket: net.Socket, content: string) {
     setTimeout(() => socket.destroy(), 0);
 }
 
+export function makeAbortableRequest(server: Mockttp, path: string) {
+    if (isNode) {
+        let req = http.request({
+            method: 'POST',
+            hostname: 'localhost',
+            port: server.port,
+            path
+        });
+        req.on('error', () => {});
+        return req;
+    } else {
+        let abortController = new AbortController();
+        fetch(server.urlFor(path), {
+            method: 'POST',
+            signal: abortController.signal as AbortSignal
+        }).catch(() => {});
+        return abortController;
+    }
+}
+
 export function watchForEvent(event: string, ...servers: Mockttp[]) {
     let eventResult: any;
 


### PR DESCRIPTION
Abort the passthrough request when the client request is prematurely closed. 
Fixes #116.