### PR TITLE
Fix mocha async `describe` 

### DIFF
--- a/test/integration/proxying/https-proxying.spec.ts
+++ b/test/integration/proxying/https-proxying.spec.ts
@@ -107,12 +107,16 @@ nodeOnly(() => {
                 ]);
             });
 
-            describe("given an untrusted upstream certificate", async () => {
+            describe("given an untrusted upstream certificate", () => {
 
                 let badServer: Mockttp;
+                let cert: Buffer;
 
                 const certPath = './test/fixtures/untrusted-ca.pem';
-                const cert = await fs.readFile(certPath);
+
+                before(async () => {
+                    cert = await fs.readFile(certPath);
+                });
 
                 beforeEach(async () => {
                     badServer = getLocal({


### PR DESCRIPTION
The mocha test suite got unstable after merging https://github.com/httptoolkit/mockttp/pull/119. The instability comes from the fact that Mocha doesn't support async `describe` blocks (https://github.com/mochajs/mocha/issues/2975). 

This PR addresses this issue by converting back the `describe` block to a sync function and moving the async logic to a `before` block.