### PR TITLE
Handle promise rejection in request recording

### DIFF
--- a/src/rules/requests/request-rule.ts
+++ b/src/rules/requests/request-rule.ts
@@ -82,11 +82,14 @@ export class RequestRule implements RequestRule {
                 ])
                 .catch(() => {}) // Ignore handler errors here - we're only tracking the request
                 .then(() => waitForCompletedRequest(req))
-                .catch(() => {
+                .catch((): CompletedRequest => {
                     // If for some reason the request is not completed, we still want to record it.
                     // TODO: Update the body to return the data that has been received so far.
-                    const completedRequest = buildInitiatedRequest(req);
-                    return {...completedRequest, body: buildBodyReader(Buffer.from([]), req.headers) };
+                    const initiatedRequest = buildInitiatedRequest(req);
+                    return {
+                        ...initiatedRequest,
+                        body: buildBodyReader(Buffer.from([]), req.headers)
+                    };
                 })
             );
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,9 +350,10 @@ export interface MockedEndpoint {
      * lists are immutable, so won't change if more requests arrive in future.
      * Call `getSeenRequests` again later to get an updated list.
      *
-     * Requests are included here once the response is completed, even if the
-     * responses failed or exceptions are thrown elsewhere. To watch for errors
-     * or detailed response info, look at the various server.on(event) methods.
+     * Requests are included here once the response is completed, even if the request 
+     * itself failed, the responses failed or exceptions are thrown elsewhere. To 
+     * watch for errors or detailed response info, look at the various server.on(event) 
+     * methods.
      */
     getSeenRequests(): Promise<CompletedRequest[]>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,9 +350,9 @@ export interface MockedEndpoint {
      * lists are immutable, so won't change if more requests arrive in future.
      * Call `getSeenRequests` again later to get an updated list.
      *
-     * Requests are included here once the response is completed, even if the request 
-     * itself failed, the responses failed or exceptions are thrown elsewhere. To 
-     * watch for errors or detailed response info, look at the various server.on(event) 
+     * Requests are included here once the response is completed, even if the request
+     * itself failed, the responses failed or exceptions are thrown elsewhere. To
+     * watch for errors or detailed response info, look at the various server.on(event)
      * methods.
      */
     getSeenRequests(): Promise<CompletedRequest[]>;

--- a/test/integration/proxying/http-proxying.spec.ts
+++ b/test/integration/proxying/http-proxying.spec.ts
@@ -941,7 +941,7 @@ nodeOnly(() => {
             it('should gracefully handle client connection getting closed in the middle of the body', async () => {
                 const seenRequestPromise = getDeferred<Request>();
                 remoteServer.on('request-initiated', (r) => seenRequestPromise.resolve(r));
-                
+
                 const seenAbortPromise = getDeferred<AbortedRequest>();
                 remoteServer.on('abort', (r) => seenAbortPromise.resolve(r));
 
@@ -955,7 +955,7 @@ nodeOnly(() => {
 
                 abortableRequest.write('some data');
 
-                // Wait for the request to be seen by the upstream server, before aborting the 
+                // Wait for the request to be seen by the upstream server, before aborting the
                 // client request.
                 const seenRequest = await seenRequestPromise;
                 abortableRequest.abort();

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -37,6 +37,12 @@ if (isNode) {
     require('./fixtures/websocket-test-server');
 }
 
+// In some cases, Mocha fails to properly surface unhandled rejections, so we do it ourselves.
+// https://github.com/mochajs/mocha/issues/2640
+process.on('unhandledRejection', (reason, promise) => {
+    throw reason;
+});
+
 chai.use(chaiAsPromised);
 chai.use(chaiFetch);
 


### PR DESCRIPTION
This PR fixes #120, by handling the case where `waitForCompletedRequest` rejects when a request gets canceled in the middle of sending the request body.

With this change `getSeenRequests` would also return incomplete requests. For now, incomplete request bodies are empty, but ideally, incomplete requests bodies should return the data that has been received so far.