### PR TITLE
Allow setting `ignoreHostHttpsErrors` to a boolean value

### DIFF
--- a/src/rules/passthrough-handling.ts
+++ b/src/rules/passthrough-handling.ts
@@ -247,3 +247,25 @@ export function getContentLengthAfterModification(
 
     return lengthOverride;
 }
+
+// Function to check if we should skip https errors for the current hostname and port,
+// based on the given config
+export function shouldUseStrictHttps(
+    hostname: string,
+    port: string,
+    ignoreHostHttpsErrors: string[] | boolean
+) {
+    let skipHttpsErrors = false;
+
+    if (ignoreHostHttpsErrors === true) {
+        // Ignore cert errors if `ignoreHostHttpsErrors` is set to true, or
+        skipHttpsErrors = true;
+    } else if (Array.isArray(ignoreHostHttpsErrors) && (
+        // if the whole hostname or host+port is whitelisted
+        _.includes(ignoreHostHttpsErrors, hostname) ||
+        _.includes(ignoreHostHttpsErrors, `${hostname}:${port}`)
+    )) {
+        skipHttpsErrors = true;
+    }
+    return !skipHttpsErrors;
+}

--- a/src/rules/requests/request-handler-definitions.ts
+++ b/src/rules/requests/request-handler-definitions.ts
@@ -486,9 +486,11 @@ export interface PassThroughHandlerOptions {
 
     /**
      * A list of hostnames for which server certificate and TLS version errors
-     * should be ignored (none, by default).
+     * should be ignored (none, by default). If set to 'true', ignore HTTPS errors
+     * for all hosts. (WARNING: Use this at your own risk. This can open your
+     * application to MITM attacks)
      */
-    ignoreHostHttpsErrors?: string[];
+    ignoreHostHttpsErrors?: string[] | boolean;
 
     /**
      * An array of additional certificates, which should be trusted as certificate
@@ -746,7 +748,7 @@ export interface SerializedPassThroughData {
     forwardToLocation?: string;
     forwarding?: ForwardingOptions;
     proxyConfig?: SerializedProxyConfig;
-    ignoreHostCertificateErrors?: string[]; // Doesn't match option name, backward compat
+    ignoreHostCertificateErrors?: string[] | boolean; // Doesn't match option name, backward compat
     extraCACertificates?: Array<{ cert: string } | { certPath: string }>;
     clientCertificateHostMap?: { [host: string]: { pfx: string, passphrase?: string } };
     lookupOptions?: PassThroughLookupOptions;
@@ -800,7 +802,7 @@ export class PassThroughHandlerDefinition extends Serializable implements Reques
 
     public readonly forwarding?: ForwardingOptions;
 
-    public readonly ignoreHostHttpsErrors: string[] = [];
+    public readonly ignoreHostHttpsErrors: string[] | boolean = [];
     public readonly clientCertificateHostMap: {
         [host: string]: { pfx: Buffer, passphrase?: string }
     };
@@ -846,8 +848,8 @@ export class PassThroughHandlerDefinition extends Serializable implements Reques
         this.forwarding = forwarding;
 
         this.ignoreHostHttpsErrors = options.ignoreHostHttpsErrors || [];
-        if (!Array.isArray(this.ignoreHostHttpsErrors)) {
-            throw new Error("ignoreHostHttpsErrors must be an array");
+        if (!Array.isArray(this.ignoreHostHttpsErrors) && typeof this.ignoreHostHttpsErrors !== 'boolean') {
+            throw new Error("ignoreHostHttpsErrors must be an array or a boolean");
         }
 
         this.lookupOptions = options.lookupOptions;

--- a/src/rules/requests/request-handlers.ts
+++ b/src/rules/requests/request-handlers.ts
@@ -632,9 +632,18 @@ export class PassThroughHandler extends PassThroughHandlerDefinition {
 
         const hostWithPort = `${hostname}:${port}`
 
+        let hostInIgnoreList = false;
+        if (typeof this.ignoreHostHttpsErrors === 'boolean' && this.ignoreHostHttpsErrors) {
+            hostInIgnoreList = true;
+        } else if (Array.isArray(this.ignoreHostHttpsErrors) && (
+            _.includes(this.ignoreHostHttpsErrors, hostname) ||
+            _.includes(this.ignoreHostHttpsErrors, hostWithPort)
+        )) {
+            hostInIgnoreList = true
+        }
         // Ignore cert errors if the host+port or whole hostname is whitelisted
-        const strictHttpsChecks = !_.includes(this.ignoreHostHttpsErrors, hostname) &&
-            !_.includes(this.ignoreHostHttpsErrors, hostWithPort);
+        // or if ignoreHostHttpsErrors is set to true
+        const strictHttpsChecks = !hostInIgnoreList
 
         // Use a client cert if it's listed for the host+port or whole hostname
         const clientCert = this.clientCertificateHostMap[hostWithPort] ||

--- a/src/rules/requests/request-handlers.ts
+++ b/src/rules/requests/request-handlers.ts
@@ -73,7 +73,8 @@ import {
     getH2HeadersAfterModification,
     OVERRIDABLE_REQUEST_PSEUDOHEADERS,
     buildOverriddenBody,
-    UPSTREAM_TLS_OPTIONS
+    UPSTREAM_TLS_OPTIONS,
+    shouldUseStrictHttps
 } from '../passthrough-handling';
 
 import {
@@ -632,18 +633,9 @@ export class PassThroughHandler extends PassThroughHandlerDefinition {
 
         const hostWithPort = `${hostname}:${port}`
 
-        let hostInIgnoreList = false;
-        if (typeof this.ignoreHostHttpsErrors === 'boolean' && this.ignoreHostHttpsErrors) {
-            hostInIgnoreList = true;
-        } else if (Array.isArray(this.ignoreHostHttpsErrors) && (
-            _.includes(this.ignoreHostHttpsErrors, hostname) ||
-            _.includes(this.ignoreHostHttpsErrors, hostWithPort)
-        )) {
-            hostInIgnoreList = true
-        }
-        // Ignore cert errors if the host+port or whole hostname is whitelisted
-        // or if ignoreHostHttpsErrors is set to true
-        const strictHttpsChecks = !hostInIgnoreList
+        const strictHttpsChecks = shouldUseStrictHttps(
+            hostname as string, port as string, this.ignoreHostHttpsErrors
+        );
 
         // Use a client cert if it's listed for the host+port or whole hostname
         const clientCert = this.clientCertificateHostMap[hostWithPort] ||

--- a/src/rules/websockets/websocket-handler-definitions.ts
+++ b/src/rules/websockets/websocket-handler-definitions.ts
@@ -49,9 +49,11 @@ export interface PassThroughWebSocketHandlerOptions {
 
     /**
      * A list of hostnames for which server certificate and TLS version errors
-     * should be ignored (none, by default).
+     * should be ignored (none, by default). If set to 'true', ignore HTTPS errors
+     * for all hosts. (WARNING: Use this at your own risk. This can open your
+     * application to MITM attacks)
      */
-    ignoreHostHttpsErrors?: string[];
+    ignoreHostHttpsErrors?: string[] | boolean;
 
     /**
      * An array of additional certificates, which should be trusted as certificate
@@ -99,7 +101,7 @@ export interface SerializedPassThroughWebSocketData {
     forwarding?: ForwardingOptions;
     lookupOptions?: PassThroughLookupOptions;
     proxyConfig?: SerializedProxyConfig;
-    ignoreHostCertificateErrors?: string[]; // Doesn't match option name, backward compat
+    ignoreHostCertificateErrors?: string[] | boolean; // Doesn't match option name, backward compat
     extraCACertificates?: Array<{ cert: string } | { certPath: string }>;
 }
 
@@ -111,17 +113,16 @@ export class PassThroughWebSocketHandlerDefinition extends Serializable implemen
     public readonly proxyConfig?: ProxyConfig;
 
     public readonly forwarding?: ForwardingOptions;
-    public readonly ignoreHostHttpsErrors: string[] = [];
+    public readonly ignoreHostHttpsErrors: string[] | boolean = [];
 
     public readonly extraCACertificates: Array<{ cert: string | Buffer } | { certPath: string }> = [];
 
     constructor(options: PassThroughWebSocketHandlerOptions = {}) {
         super();
 
-        this.ignoreHostHttpsErrors = options.ignoreHostHttpsErrors ||
-            [];
-        if (!Array.isArray(this.ignoreHostHttpsErrors)) {
-            throw new Error("ignoreHostHttpsErrors must be an array");
+        this.ignoreHostHttpsErrors = options.ignoreHostHttpsErrors || [];
+        if (!Array.isArray(this.ignoreHostHttpsErrors) && typeof this.ignoreHostHttpsErrors !== 'boolean') {
+            throw new Error("ignoreHostHttpsErrors must be an array or a boolean");
         }
 
         // If a location is provided, and it's not a bare hostname, it must be parseable

--- a/test/integration/proxying/https-proxying.spec.ts
+++ b/test/integration/proxying/https-proxying.spec.ts
@@ -188,6 +188,21 @@ nodeOnly(() => {
                     expect(response.statusCode).to.equal(502);
                 });
 
+                it("should allow passing through requests if all the hosts are whitelisted", async () => {
+                    await badServer.forAnyRequest().thenReply(200);
+
+                    await server.forAnyRequest().thenPassThrough({
+                        ignoreHostHttpsErrors: true
+                    });
+
+                    let response = await request.get(badServer.url, {
+                        resolveWithFullResponse: true,
+                        simple: false
+                    });
+
+                    expect(response.statusCode).to.equal(200);
+                });
+
                 it("should allow passing through requests if the certificate is specifically listed", async () => {
                     await badServer.forAnyRequest().thenReply(200);
 


### PR DESCRIPTION
Setting `ignoreHostHttpsErrors` to `true` will ignore SSL errors for all hosts. Setting it to `false` is equivalent to setting it to an empty array.

This will fix #128

@pimterry If you can confirm that the approach taken (and everything else) is fine, I will do this for websockets also.

Also, can you tell me why there are two tests with description `should refuse to pass through requests if a non\-matching host is listed` in `test/integration/proxying/https-proxying.spec.ts`. Will I also have to add another test?