### PR TITLE
fix updating host header when beforeRequest and forwarding is set

### DIFF
--- a/src/rules/requests/request-handlers.ts
+++ b/src/rules/requests/request-handlers.ts
@@ -573,7 +573,7 @@ export class PassThroughHandler extends PassThroughHandlerDefinition {
             const completedRequest = await waitForCompletedRequest(clientReq);
             const modifiedReq = await this.beforeRequest({
                 ...completedRequest,
-                headers: _.cloneDeep(completedRequest.headers),
+                headers: _.cloneDeep(rawHeadersToObject(completedRequest.rawHeaders)),
                 rawHeaders: _.cloneDeep(completedRequest.rawHeaders)
             });
 
@@ -597,16 +597,18 @@ export class PassThroughHandler extends PassThroughHandlerDefinition {
             reqUrl = modifiedReq?.url || reqUrl;
 
             headersManuallyModified = !!modifiedReq?.headers;
-            let headers = modifiedReq?.headers || clientReq.headers;
-
+            const clientHeaders = rawHeadersToObject(clientReq.rawHeaders)
+            let headers = modifiedReq?.headers || clientHeaders;
             Object.assign(headers,
                 isH2Downstream
-                    ? getH2HeadersAfterModification(reqUrl, clientReq.headers, modifiedReq?.headers)
-                    : { 'host': getHostAfterModification(reqUrl, clientReq.headers, modifiedReq?.headers) }
+                    ? getH2HeadersAfterModification(reqUrl, clientHeaders, modifiedReq?.headers)
+                    : !this.forwarding || !this.forwarding.updateHostHeader
+                        ? { 'host': getHostAfterModification(reqUrl, clientHeaders, modifiedReq?.headers) } 
+                        : {}
             );
 
             validateCustomHeaders(
-                clientReq.headers,
+                clientHeaders,
                 modifiedReq?.headers,
                 OVERRIDABLE_REQUEST_PSEUDOHEADERS // These are handled by getCorrectPseudoheaders above
             );
@@ -617,7 +619,7 @@ export class PassThroughHandler extends PassThroughHandlerDefinition {
                 // Automatically match the content-length to the body, unless it was explicitly overriden.
                 headers['content-length'] = getContentLengthAfterModification(
                     reqBodyOverride,
-                    clientReq.headers,
+                    clientHeaders,
                     modifiedReq?.headers
                 );
             }

--- a/src/rules/requests/request-handlers.ts
+++ b/src/rules/requests/request-handlers.ts
@@ -599,13 +599,13 @@ export class PassThroughHandler extends PassThroughHandlerDefinition {
             headersManuallyModified = !!modifiedReq?.headers;
             const clientHeaders = rawHeadersToObject(clientReq.rawHeaders)
             let headers = modifiedReq?.headers || clientHeaders;
-            Object.assign(headers,
-                isH2Downstream
-                    ? getH2HeadersAfterModification(reqUrl, clientHeaders, modifiedReq?.headers)
-                    : !this.forwarding || !this.forwarding.updateHostHeader
-                        ? { 'host': getHostAfterModification(reqUrl, clientHeaders, modifiedReq?.headers) } 
-                        : {}
-            );
+            if (!this.forwarding || this.forwarding.updateHostHeader === false) {
+                Object.assign(headers,
+                    isH2Downstream
+                        ? getH2HeadersAfterModification(reqUrl, clientHeaders, modifiedReq?.headers)
+                        :  { 'host': getHostAfterModification(reqUrl, clientHeaders, modifiedReq?.headers) } 
+                );
+            }
 
             validateCustomHeaders(
                 clientHeaders,

--- a/test/integration/proxying/proxy-transforms.spec.ts
+++ b/test/integration/proxying/proxy-transforms.spec.ts
@@ -102,6 +102,19 @@ nodeOnly(() => {
                 let seenRequests = await remoteEndpointMock.getSeenRequests();
                 expect(seenRequests[0].headers.host).to.equal('google.com');
             });
+
+            it("can update the host header when used with beforeRequest", async () => {
+                let remoteEndpointMock = await remoteServer.forGet('/get').thenReply(200, "mocked data");
+                await server.forAnyRequest().thenForwardTo(remoteServer.url, {
+                    beforeRequest: () => {},
+                    forwarding: { updateHostHeader: true }
+                });
+
+                await request.get(server.urlFor("/get"));
+
+                let seenRequests = await remoteEndpointMock.getSeenRequests();
+                expect(seenRequests[0].headers.host).to.equal(`localhost:${remoteServer.port}`);
+            });
         });
 
         describe("that transforms requests automatically", () => {


### PR DESCRIPTION
Fixes: https://github.com/httptoolkit/mockttp/issues/137

Fixes `forwarding.updateHostHeader` when being used with `beforeRequest` - there were two issues here:
- rawHeaders was being updated in the `forwarding` block, but `req.headers` was being referenced
- `getHostAfterModification` was modifying the host header for http1 requests + overwriting it. 

