### PR TITLE
Support returning streams from callbacks

### DIFF
--- a/src/rules/requests/request-handler-definitions.ts
+++ b/src/rules/requests/request-handler-definitions.ts
@@ -204,7 +204,7 @@ export interface CallbackResponseMessageResult {
      * You should only return one body field: either `body`, `rawBody` or
      * `json`.
      */
-    rawBody?: Buffer | Uint8Array;
+    rawBody?: Buffer | Uint8Array | Readable;
 
     /**
      * A JSON value, which will be stringified and send as a JSON-encoded

--- a/src/rules/requests/request-handlers.ts
+++ b/src/rules/requests/request-handlers.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs/promises';
 import * as h2Client from 'http2-wrapper';
 import CacheableLookup from 'cacheable-lookup';
 import { decode as decodeBase64 } from 'base64-arraybuffer';
-import { Transform } from 'stream';
+import { Readable, Transform } from 'stream';
 import { stripIndent, oneLine } from 'common-tags';
 import { TypedError } from 'typed-error';
 
@@ -183,7 +183,12 @@ async function writeResponseFromCallback(result: CallbackResponseMessageResult, 
         result.statusMessage,
         result.headers
     );
-    response.end(result.rawBody || "");
+
+    if (result.rawBody instanceof Readable) {
+        (result.rawBody as Readable).pipe(response);
+    } else {
+        response.end(result.rawBody || "");
+    }
 }
 
 export class CallbackHandler extends CallbackHandlerDefinition {

--- a/src/serialization/body-serialization.ts
+++ b/src/serialization/body-serialization.ts
@@ -7,6 +7,7 @@ import { buildBodyReader, isMockttpBody } from "../util/request-utils";
 import { Replace } from "../util/type-utils";
 
 import { deserializeBuffer, serializeBuffer } from "./serialization";
+import { Readable } from 'stream';
 
 export function withSerializedBodyReader<T extends {
     body: CompletedBody
@@ -33,7 +34,7 @@ export function withDeserializedBodyReader<T extends { headers: Headers, body: C
  */
 export function withSerializedCallbackBuffers<T extends {
     body?: CompletedBody | Buffer | Uint8Array | ArrayBuffer | string,
-    rawBody?: Buffer | Uint8Array
+    rawBody?: Buffer | Uint8Array | Readable
 }>(input: T): Replace<T, { body: string | undefined }> {
     let serializedBody: string | undefined;
 
@@ -52,7 +53,7 @@ export function withSerializedCallbackBuffers<T extends {
     return {
         ...input,
         body: serializedBody,
-        rawBody: input.rawBody
+        rawBody: input.rawBody && !(input.rawBody instanceof Readable)
             ? serializeBuffer(asBuffer(input.rawBody))
             : undefined
     };


### PR DESCRIPTION
You can now pass a `Readable` stream into `rawBody` inside `thenCallback`.

Fixes #98 