### PR TITLE
Add option `tlsIntercept`

### DIFF
--- a/src/mockttp.ts
+++ b/src/mockttp.ts
@@ -696,6 +696,18 @@ export type MockttpHttpsOptions = CAOptions & {
      * here for additional configuration of this behaviour.
      */
     tlsPassthrough?: Array<{ hostname: string }>
+
+    /**
+     * A list of hostnames that should only be intercepted.
+     * 
+     * When set, only connections to these hostnames will be intercepted, and all
+     * other connections will be passed through without interception.
+     * 
+     * Each element in the list must be an object with a 'hostname' field for the
+     * hostname that should be matched. In future more options may be supported
+     * here for additional configuration of this behaviour.
+     */
+    tlsIntercept?: Array<{ hostname: string }>
 };
 
 export interface MockttpOptions {

--- a/src/mockttp.ts
+++ b/src/mockttp.ts
@@ -691,23 +691,30 @@ export type MockttpHttpsOptions = CAOptions & {
      * sent raw to the upstream hostname, without handling TLS within Mockttp (i.e.
      * with no TLS interception performed).
      *
-     * Each element in the list must be an object with a 'hostname' field for the
+     * This option is mutually exclusive with `tlsInterceptOnly` and setting both
+     * options will throw an error.
+     *
+     * Each element in this list must be an object with a 'hostname' field for the
      * hostname that should be matched. In future more options may be supported
      * here for additional configuration of this behaviour.
      */
-    tlsPassthrough?: Array<{ hostname: string }>
+    tlsPassthrough?: Array<{ hostname: string }>;
 
     /**
-     * A list of hostnames that should only be intercepted.
-     * 
-     * When set, only connections to these hostnames will be intercepted, and all
-     * other connections will be passed through without interception.
-     * 
-     * Each element in the list must be an object with a 'hostname' field for the
+     * A limited list of the only hostnames whose TLS should be intercepted.
+     *
+     * This is the opposite of `tlsPassthrough`. When set, only connections
+     * to these hostnames will be intercepted, and all other TLS connections will
+     * be passed through without interception.
+     *
+     * This option is mutually exclusive with `tlsPassthrough` and setting both
+     * options will throw an error.
+     *
+     * Each element in this list must be an object with a 'hostname' field for the
      * hostname that should be matched. In future more options may be supported
      * here for additional configuration of this behaviour.
      */
-    tlsIntercept?: Array<{ hostname: string }>
+    tlsInterceptOnly?: Array<{ hostname: string }>;
 };
 
 export interface MockttpOptions {

--- a/src/server/http-combo-server.ts
+++ b/src/server/http-combo-server.ts
@@ -200,8 +200,8 @@ export async function createComboServer(
 
         analyzeAndMaybePassThroughTls(
             tlsServer,
-            options.https.tlsPassthrough ?? [],
-            options.https.tlsIntercept ?? [],
+            options.https.tlsPassthrough,
+            options.https.tlsInterceptOnly,
             tlsPassthroughListener
         );
 
@@ -363,21 +363,21 @@ function copyTimingDetails<T extends SocketIsh<'__timingInfo'>>(
 }
 
 /**
- * Takes a tls passthrough list (may be empty), and reconfigures a given TLS server so that all
+ * Takes tls passthrough configuration (may be empty) and reconfigures a given TLS server so that all
  * client hellos are parsed, matching requests are passed to the given passthrough listener (without
  * continuing setup) and client hello metadata is attached to all sockets.
  */
 function analyzeAndMaybePassThroughTls(
     server: tls.Server,
-    passthroughList: Required<MockttpHttpsOptions>['tlsPassthrough'],
-    interceptList: Required<MockttpHttpsOptions>['tlsIntercept'],
+    passthroughList: Required<MockttpHttpsOptions>['tlsPassthrough'] | undefined,
+    interceptOnlyList: Required<MockttpHttpsOptions>['tlsInterceptOnly'] | undefined,
     passthroughListener: (socket: net.Socket, address: string, port?: number) => void
 ) {
-    if (passthroughList.length > 0 && interceptList.length > 0){
-        throw new Error('Cannot use both tlsPassthrough and tlsIntercept at the same time.');
+    if (passthroughList && interceptOnlyList){
+        throw new Error('Cannot use both tlsPassthrough and tlsInterceptOnly options at the same time.');
     }
-    const passThroughHostnames = passthroughList.map(({ hostname }) => hostname);
-    const interceptHostnames = interceptList.map(({ hostname }) => hostname);
+    const passThroughHostnames = passthroughList?.map(({ hostname }) => hostname) ?? [];
+    const interceptOnlyHostnames = interceptOnlyList?.map(({ hostname }) => hostname);
 
     const tlsConnectionListener = server.listeners('connection')[0] as (socket: net.Socket) => {};
     server.removeListener('connection', tlsConnectionListener);
@@ -395,22 +395,13 @@ function analyzeAndMaybePassThroughTls(
                 clientAlpn: helloData.alpnProtocols,
                 ja3Fingerprint: calculateJa3FromFingerprintData(helloData.fingerprintData)
             };
-            
-            if (interceptHostnames.length > 0 && connectHostname && !interceptHostnames.includes(connectHostname)) {
-                const upstreamPort = connectPort ? parseInt(connectPort, 10) : undefined;
-                passthroughListener(socket, connectHostname, upstreamPort);
-                return; // Do not continue with TLS
-            } else if (interceptHostnames.length > 0 && sniHostname && !interceptHostnames.includes(sniHostname)) {
-                passthroughListener(socket, sniHostname); // Can't guess the port - not included in SNI
-                return; // Do not continue with TLS
-            }
 
-            if (connectHostname && passThroughHostnames.includes(connectHostname)) {
+            if (shouldPassThrough(connectHostname, passThroughHostnames, interceptOnlyHostnames)) {
                 const upstreamPort = connectPort ? parseInt(connectPort, 10) : undefined;
                 passthroughListener(socket, connectHostname, upstreamPort);
                 return; // Do not continue with TLS
-            } else if (sniHostname && passThroughHostnames.includes(sniHostname)) {
-                passthroughListener(socket, sniHostname); // Can't guess the port - not included in SNI
+            } else if (shouldPassThrough(sniHostname, passThroughHostnames, interceptOnlyHostnames)) {
+                passthroughListener(socket, sniHostname!); // Can't guess the port - not included in SNI
                 return; // Do not continue with TLS
             }
         } catch (e) {
@@ -424,4 +415,19 @@ function analyzeAndMaybePassThroughTls(
         // Didn't match a passthrough hostname - continue with TLS setup
         tlsConnectionListener.call(server, socket);
     });
+}
+
+function shouldPassThrough(
+    hostname: string | undefined,
+    // Only one of these two should have values (validated above):
+    passThroughHostnames: string[],
+    interceptOnlyHostnames: string[] | undefined
+): boolean {
+    if (!hostname) return false;
+
+    if (interceptOnlyHostnames) {
+        return !interceptOnlyHostnames.includes(hostname);
+    }
+
+    return passThroughHostnames.includes(hostname);
 }

--- a/test/integration/https.spec.ts
+++ b/test/integration/https.spec.ts
@@ -257,7 +257,7 @@ describe("When configured for HTTPS", () => {
                 https: {
                     keyPath: './test/fixtures/test-ca.key',
                     certPath: './test/fixtures/test-ca.pem',
-                    tlsIntercept: [
+                    tlsInterceptOnly: [
                         { hostname: 'wikipedia.org' }
                     ]
                 }

--- a/test/integration/https.spec.ts
+++ b/test/integration/https.spec.ts
@@ -252,5 +252,59 @@ describe("When configured for HTTPS", () => {
             });
         });
 
+        describe("with some hostnames included", () => {
+            let server = getLocal({
+                https: {
+                    keyPath: './test/fixtures/test-ca.key',
+                    certPath: './test/fixtures/test-ca.pem',
+                    tlsIntercept: [
+                        { hostname: 'wikipedia.org' }
+                    ]
+                }
+            });
+
+            beforeEach(async () => {
+                await server.start();
+                await server.forGet('/').thenReply(200, "Mock response");
+            });
+
+            afterEach(async () => {
+                await server.stop()
+            });
+
+            it("handles matching HTTPS requests", async () => {
+                const response: http.IncomingMessage = await new Promise((resolve) =>
+                    https.get({
+                        host: 'localhost',
+                        port: server.port,
+                        servername: 'wikipedia.org',
+                        headers: { 'Host': 'wikipedia.org' }
+                    }).on('response', resolve)
+                );
+
+                expect(response.statusCode).to.equal(200);
+                const body = (await streamToBuffer(response)).toString();
+                expect(body).to.equal("Mock response");
+            });
+
+            it("skips the server for non-matching HTTPS requests", async function () {
+                this.retries(3); // Example.com can be unreliable
+
+                const response: http.IncomingMessage = await new Promise((resolve, reject) =>
+                    https.get({
+                        host: 'localhost',
+                        port: server.port,
+                        servername: 'example.com',
+                        headers: { 'Host': 'example.com' }
+                    }).on('response', resolve).on('error', reject)
+                );
+
+                expect(response.statusCode).to.equal(200);
+                const body = (await streamToBuffer(response)).toString();
+                expect(body).to.include(
+                    "This domain is for use in illustrative examples in documents."
+                );
+            });
+        });
     });
 });


### PR DESCRIPTION
This PR adds an option `tlsIntercept` to `MockttpHttpsOptions`. This option is the inverse of the existing `tlsPassthrough`:
- `tlsPassthrough`: intercept everything except hostnames in this list
- `tlsIntercept`: intercept nothing except hostnames in this list

Both options can not be used at the same time.

This option allows `mockttp` to be less intrusive and to let most requests untouched, except for a specific list of hostnames. This helps keep some applications using certificate pinning working correctly.

Related issue: #162 

@pimterry let me know if you'd prefer more tests and/or if docs need to be adjusted.