### PR TITLE
Only log socket errors if debug is enabled

### DIFF
--- a/src/server/http-combo-server.ts
+++ b/src/server/http-combo-server.ts
@@ -273,7 +273,11 @@ export async function createComboServer(
     function handleH1Connect(req: http.IncomingMessage, socket: net.Socket) {
         // Clients may disconnect at this point (for all sorts of reasons), but here
         // nothing else is listening, so we need to catch errors on the socket:
-        socket.once('error', (e) => console.log('Error on client socket', e));
+        socket.once('error', (e) => {
+            if (options.debug) {
+                console.log('Error on client socket', e);
+            }
+        });
 
         const connectUrl = req.url || req.headers['host'];
         if (!connectUrl) {


### PR DESCRIPTION
Similar to https://github.com/httptoolkit/mockttp/issues/148, I'm finding the logging of socket errors to be too noisy. Even with the proxy setup to only intercept a specific domain (via `tlsInterceptOnly`), errors such as `ECONNRESET` or `EPIPE` happen frequently on other requests.

Following a similar approach as suggested in https://github.com/httptoolkit/mockttp/issues/148, this PR puts the `console.log` in the socket error listener behind `options.debug`. These errors being somewhat expected (comment says: _Clients may disconnect at this point (for all sorts of reasons)_), it seems reasonable to require the debug option to be set for them to be logged.