### PR TITLE
Add wildcard support for passthrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "semver": "^7.5.3",
     "socks-proxy-agent": "^7.0.0",
     "typed-error": "^3.0.2",
+    "urlpattern-polyfill": "^10.0.0",
     "uuid": "^8.3.2",
     "ws": "^8.8.0"
   }

--- a/src/server/http-combo-server.ts
+++ b/src/server/http-combo-server.ts
@@ -421,7 +421,7 @@ function analyzeAndMaybePassThroughTls(
     });
 }
 
-function shouldPassThrough(
+export function shouldPassThrough(
     hostname: string | undefined,
     // Only one of these two should have values (validated above):
     passThroughHostnames: string[],

--- a/src/server/http-combo-server.ts
+++ b/src/server/http-combo-server.ts
@@ -14,6 +14,7 @@ import {
     NonTlsError,
     readTlsClientHello
 } from 'read-tls-client-hello';
+import { URLPattern } from "urlpattern-polyfill";
 
 import { TlsHandshakeFailure } from '../types';
 import { getCA } from '../util/tls';
@@ -426,12 +427,16 @@ export function shouldPassThrough(
     // Only one of these two should have values (validated above):
     passThroughHostnames: string[],
     interceptOnlyHostnames: string[] | undefined
-): boolean {
+  ): boolean {
     if (!hostname) return false;
-
+  
     if (interceptOnlyHostnames) {
-        return !interceptOnlyHostnames.includes(hostname);
+      return !interceptOnlyHostnames.some((hn) =>
+        new URLPattern(`https://${hn}`).test(`https://${hostname}`)
+      );
     }
-
-    return passThroughHostnames.includes(hostname);
-}
+  
+    return passThroughHostnames.some((hn) =>
+      new URLPattern(`https://${hn}`).test(`https://${hostname}`)
+    );
+  }

--- a/test/http-combo-server.spec.ts
+++ b/test/http-combo-server.spec.ts
@@ -1,3 +1,4 @@
+import { URLPattern } from "urlpattern-polyfill";
 import { shouldPassThrough } from "../src/server/http-combo-server";
 import { expect } from "./test-utils";
 
@@ -21,7 +22,7 @@ describe("shouldPassThrough", () => {
     it("should return true when hostname is in passThroughHostnames", () => {
       const should = shouldPassThrough(
         "example.org",
-        ["example.org"],
+        [new URLPattern("https://example.org")],
         undefined
       );
       expect(should).to.be.true;
@@ -30,30 +31,46 @@ describe("shouldPassThrough", () => {
     it("should return false when hostname is not in passThroughHostnames", () => {
       const should = shouldPassThrough(
         "example.org",
-        ["example.com"],
+        [new URLPattern("https://example.com")],
         undefined
       );
       expect(should).to.be.false;
     });
 
     it("should return true when hostname match a wildcard", () => {
-      const should = shouldPassThrough("example.org", ["*.org"], undefined);
+      const should = shouldPassThrough(
+        "example.org",
+        [new URLPattern("https://*.org")],
+        undefined
+      );
       expect(should).to.be.true;
     });
   });
   describe("interceptOnlyHostnames", () => {
     it("should return false when hostname is in interceptOnlyHostnames", () => {
-      const should = shouldPassThrough("example.org", [], ["example.org"]);
+      const should = shouldPassThrough(
+        "example.org",
+        [],
+        [new URLPattern("https://example.org")]
+      );
       expect(should).to.be.false;
     });
 
     it("should return true when hostname is not in interceptOnlyHostnames", () => {
-      const should = shouldPassThrough("example.org", [], ["example.com"]);
+      const should = shouldPassThrough(
+        "example.org",
+        [],
+        [new URLPattern("https://example.com")]
+      );
       expect(should).to.be.true;
     });
 
     it("should return false when hostname match a wildcard", () => {
-      const should = shouldPassThrough("example.org", [], ["*.org"]);
+      const should = shouldPassThrough(
+        "example.org",
+        [],
+        [new URLPattern("https://*.org")]
+      );
       expect(should).to.be.false;
     });
   });

--- a/test/http-combo-server.spec.ts
+++ b/test/http-combo-server.spec.ts
@@ -35,6 +35,11 @@ describe("shouldPassThrough", () => {
       );
       expect(should).to.be.false;
     });
+
+    it("should return true when hostname match a wildcard", () => {
+      const should = shouldPassThrough("example.org", ["*.org"], undefined);
+      expect(should).to.be.true;
+    });
   });
   describe("interceptOnlyHostnames", () => {
     it("should return false when hostname is in interceptOnlyHostnames", () => {
@@ -45,6 +50,11 @@ describe("shouldPassThrough", () => {
     it("should return true when hostname is not in interceptOnlyHostnames", () => {
       const should = shouldPassThrough("example.org", [], ["example.com"]);
       expect(should).to.be.true;
+    });
+
+    it("should return false when hostname match a wildcard", () => {
+      const should = shouldPassThrough("example.org", [], ["*.org"]);
+      expect(should).to.be.false;
     });
   });
 });

--- a/test/http-combo-server.spec.ts
+++ b/test/http-combo-server.spec.ts
@@ -1,0 +1,50 @@
+import { shouldPassThrough } from "../src/server/http-combo-server";
+import { expect } from "./test-utils";
+
+describe("shouldPassThrough", () => {
+  it("should return false when passThroughHostnames is empty and interceptOnlyHostnames is undefined", async () => {
+    const should = shouldPassThrough("example.org", [], undefined);
+    expect(should).to.be.false;
+  });
+
+  it("should return true when both lists empty", async () => {
+    const should = shouldPassThrough("example.org", [], []);
+    expect(should).to.be.true;
+  });
+
+  it("should return false when hostname is falsy", () => {
+    const should = shouldPassThrough("", [], []);
+    expect(should).to.be.false;
+  });
+
+  describe("passThroughHostnames", () => {
+    it("should return true when hostname is in passThroughHostnames", () => {
+      const should = shouldPassThrough(
+        "example.org",
+        ["example.org"],
+        undefined
+      );
+      expect(should).to.be.true;
+    });
+
+    it("should return false when hostname is not in passThroughHostnames", () => {
+      const should = shouldPassThrough(
+        "example.org",
+        ["example.com"],
+        undefined
+      );
+      expect(should).to.be.false;
+    });
+  });
+  describe("interceptOnlyHostnames", () => {
+    it("should return false when hostname is in interceptOnlyHostnames", () => {
+      const should = shouldPassThrough("example.org", [], ["example.org"]);
+      expect(should).to.be.false;
+    });
+
+    it("should return true when hostname is not in interceptOnlyHostnames", () => {
+      const should = shouldPassThrough("example.org", [], ["example.com"]);
+      expect(should).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
This PR adds support for hostname wildcards in `passThroughHostnames` and `interceptOnlyHostnames`, as previously requested in https://github.com/httptoolkit/mockttp/issues/162.

Wildcard matching is done using [`URLPattern`](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern/URLPattern), an upcoming web standard that's perfect for this use case and may serve other purposes in mockttp. It is already implemented in [many browsers](https://caniuse.com/mdn-api_urlpattern_protocol) and nodeJS is [working on it](https://github.com/nodejs/node/issues/40844). It is currently implemented using [`urlpattern-polyfill`](https://www.npmjs.com/package/urlpattern-polyfill).

I changed the signature of `shouldPassThrough` to accept `URLPattern[]` instead of `string[]`, so we don't need to keep recreating the objects. This is purely internal, the external API is unchanged.

`shouldPassThrough` is now unit tested. I used unit tests as it seemed fitting and some of the integration tests were already failing on `main` - I'm not sure why.

Let me know if you're happy with these changes, I'll then update the docs.