### PR TITLE
Add option to constrain root CA to permitted domains

### DIFF
--- a/src/util/tls.ts
+++ b/src/util/tls.ts
@@ -110,6 +110,7 @@ export async function generateCACertificate(options: {
     if(permittedDomains.length > 0) {
         extensions.push({
             critical: true,
+            id: '2.5.29.30',
             name: 'nameConstraints',
             value: generateNameConstraints({
               permitted: permittedDomains,

--- a/test/ca.spec.ts
+++ b/test/ca.spec.ts
@@ -10,7 +10,7 @@ import { CA, generateCACertificate } from '../src/util/tls';
 const nodeMajorVersion = parseInt(process.versions.node.split('.')[0], 10);
 
 nodeOnly(() => {
-    describe.only("Certificate generation", () => {
+    describe("Certificate generation", () => {
         const caKey = fs.readFile(path.join(__dirname, 'fixtures', 'test-ca.key'), 'utf8');
         const caCert = fs.readFile(path.join(__dirname, 'fixtures', 'test-ca.pem'), 'utf8');
 

--- a/test/ca.spec.ts
+++ b/test/ca.spec.ts
@@ -58,7 +58,7 @@ nodeOnly(() => {
                             port: 4430,
                             ca: [constrainedCaCert],
                             lookup: (hostname, options, callback) => {
-                                callback(null, "127.0.0.1", 4);
+                                callback(null, [{ address: "127.0.0.1", family: 4 }]);
                             },
                         },
                         (res) => {
@@ -90,7 +90,7 @@ nodeOnly(() => {
                             port: 4430,
                             ca: [constrainedCaCert],
                             lookup: (hostname, options, callback) => {
-                                callback(null, "127.0.0.1", 4);
+                                callback(null, [{ address: "127.0.0.1", family: 4 }]);
                             },
                         },
                     );

--- a/test/ca.spec.ts
+++ b/test/ca.spec.ts
@@ -7,8 +7,10 @@ import { expect, fetch, ignoreNetworkError, nodeOnly } from "./test-utils";
 
 import { CA, generateCACertificate } from '../src/util/tls';
 
+const nodeMajorVersion = parseInt(process.versions.node.split('.')[0], 10);
+
 nodeOnly(() => {
-    describe("Certificate generation", () => {
+    describe.only("Certificate generation", () => {
         const caKey = fs.readFile(path.join(__dirname, 'fixtures', 'test-ca.key'), 'utf8');
         const caCert = fs.readFile(path.join(__dirname, 'fixtures', 'test-ca.pem'), 'utf8');
 
@@ -58,7 +60,11 @@ nodeOnly(() => {
                             port: 4430,
                             ca: [constrainedCaCert],
                             lookup: (hostname, options, callback) => {
-                                callback(null, [{ address: "127.0.0.1", family: 4 }]);
+                                if (nodeMajorVersion <= 18) {
+                                    callback(null, "127.0.0.1", 4);
+                                } else {
+                                    callback(null, [{ address: "127.0.0.1", family: 4 }]);
+                                }
                             },
                         },
                         (res) => {
@@ -90,7 +96,11 @@ nodeOnly(() => {
                             port: 4430,
                             ca: [constrainedCaCert],
                             lookup: (hostname, options, callback) => {
-                                callback(null, [{ address: "127.0.0.1", family: 4 }]);
+                                if (nodeMajorVersion <= 18) {
+                                    callback(null, "127.0.0.1", 4);
+                                } else {
+                                    callback(null, [{ address: "127.0.0.1", family: 4 }]);
+                                }
                             },
                         },
                     );


### PR DESCRIPTION
We have a use-case where we would like to trust the Root CA generated by mockttp, in order to use mockttp as a dev tool. However, as mentioned in [this page](https://github.com/httptoolkit/mockttp/blob/main/docs/setup.md#generating-a-certificate), trusting this certificate raises security concerns.

In order to mitigate the security risk linked to trusting the CA, this PR adds an option `contrainToDomains` to the `generateCACertificate()` function. Using this option will add a `nameConstraints` extension, severely limiting the scope of the CA. The CA will then only be able to correctly sign certificates for the provided domains.

The code is based on [this forge issue](https://github.com/digitalbazaar/forge/issues/958) and appears to work as intended from my tests. I have only included support for a whitelist as it seems to make most sense from a security standpoint, but happy to add support for a blacklist as well. The `generateNameConstraints` will be modified in consequence.

Should you be receptive to this change, I would really appreciate some guidance on testing this. My understanding is tests should be added in `test/ca.spec.ts`. How would you suggest to go about testing this ? My initial approach would be to generate a certificate inside/outside the nameConstraint and expect `fetch` to accept/reject a request to a server using these certificates.

