### PR TITLE
fix(url): normalizeHost with ipv6 hostname

### DIFF
--- a/src/util/url.ts
+++ b/src/util/url.ts
@@ -2,6 +2,7 @@ import * as url from 'url';
 import * as _ from 'lodash';
 
 import { nthIndexOf } from './util';
+import { isIPv6Address } from './ip-utils';
 import { Destination } from '../types';
 
 // Is this URL fully qualified?
@@ -92,11 +93,14 @@ export const getDestination = (protocol: string, host: string): Destination => {
 
 export const normalizeHost = (protocol: string, host: string) => {
     const { hostname, port } = getDestination(protocol, host);
+    const normalizedHostname = isIPv6Address(hostname)
+        ? `[${hostname}]`
+        : hostname;
 
     if (port === getDefaultPort(protocol)) {
-        return hostname;
+        return normalizedHostname;
     } else {
-        return `${hostname}:${port}`;
+        return `${normalizedHostname}:${port}`;
     }
 }
 

--- a/test/integration/subscriptions/client-error-events.spec.ts
+++ b/test/integration/subscriptions/client-error-events.spec.ts
@@ -124,13 +124,13 @@ describe("Client error subscription", () => {
                 let errorPromise = getDeferred<ClientError>();
                 await server.on('client-error', (e) => errorPromise.resolve(e));
 
-                sendRawRequest(server, 'GET /abc HTTP/1.1\r\nHost: a:1:2\r\n\r\n');
+                sendRawRequest(server, 'GET /abc HTTP/1.1\r\nHost: a^1:2\r\n\r\n');
 
                 let clientError = await errorPromise;
 
                 expect(clientError.errorCode).to.equal("ERR_INVALID_URL");
                 expect(clientError.request.method).to.equal("GET");
-                expect(clientError.request.url).to.equal("http://a:1:2/abc");
+                expect(clientError.request.url).to.equal("http://a^1:2/abc");
 
                 const response = clientError.response as CompletedResponse;
                 expect(response.statusCode).to.equal(400);

--- a/test/request-utils.spec.ts
+++ b/test/request-utils.spec.ts
@@ -1,8 +1,10 @@
 import { Buffer } from 'buffer';
 import * as zlib from 'zlib';
+import * as stream from 'stream';
 
 import { expect, nodeOnly } from './test-utils';
-import { buildBodyReader } from '../src/util/request-utils';
+import { buildBodyReader, preprocessRequest } from '../src/util/request-utils';
+import { LastHopEncrypted } from '../src/util/socket-extensions';
 
 nodeOnly(() => {
     describe("buildBodyReader", () => {
@@ -87,5 +89,35 @@ nodeOnly(() => {
             });
         });
 
+    });
+
+    describe("preprocessRequest", () => {
+        it('reconstructs valid absolute URLs from bracketed IPv6 host headers', () => {
+            const req = Object.assign(new stream.PassThrough(), {
+                method: 'GET',
+                url: '/api',
+                headers: {
+                    host: '[::1]:8000'
+                },
+                rawHeaders: ['Host', '[::1]:8000'],
+                httpVersion: '1.1',
+                socket: {
+                    [LastHopEncrypted]: false
+                }
+            }) as any;
+
+            const result = preprocessRequest(req, {
+                type: 'request',
+                serverPort: 45454,
+                maxBodySize: 1024
+            });
+
+            expect(result).to.not.equal(null);
+            expect(req.url).to.equal('http://[::1]:8000/api');
+            expect(req.destination).to.deep.equal({
+                hostname: '::1',
+                port: 8000
+            });
+        });
     });
 });

--- a/test/url-normalization.spec.ts
+++ b/test/url-normalization.spec.ts
@@ -1,8 +1,42 @@
-import { normalizeUrl } from '../src/util/url';
+import { normalizeHost, normalizeUrl } from '../src/util/url';
 
 import { expect } from "./test-utils";
 
 describe("URL normalization for matching", () => {
+    describe("host normalization", () => {
+        it("should bracket IPv6 hosts with non-default HTTP ports", () => {
+            expect(
+                normalizeHost('http', '[::1]:8000')
+            ).to.equal('[::1]:8000');
+        });
+
+        it("should bracket IPv6 hosts with non-default HTTPS ports", () => {
+            expect(
+                normalizeHost('https', '[::1]:8443')
+            ).to.equal('[::1]:8443');
+        });
+
+        it("should bracket IPv6 hosts when normalizing away the default port", () => {
+            expect(
+                normalizeHost('http', '[::1]:80')
+            ).to.equal('[::1]');
+
+            expect(
+                normalizeHost('https', '[::1]:443')
+            ).to.equal('[::1]');
+        });
+
+        it("should preserve existing formatting for IPv4 and domain hosts", () => {
+            expect(
+                normalizeHost('http', '127.0.0.1:8000')
+            ).to.equal('127.0.0.1:8000');
+
+            expect(
+                normalizeHost('https', 'example.com:443')
+            ).to.equal('example.com');
+        });
+    });
+
     it("should do nothing to fully specified URLs", () => {
         expect(
             normalizeUrl('https://example.com/abc')


### PR DESCRIPTION
Hi,

Been using `mockttp` for a long time in `http-proxy-middleware` to mock the proxy target server.

Great work on this library 🙏

Recently I updated `httpxy` (dependency of `http-proxy-middleware`) with improved IPv6 support: https://github.com/unjs/httpxy/pull/136

After updating `httpxy` some of existing IPv6 tests started to fail: https://github.com/chimurai/http-proxy-middleware/blob/ffbf5bd59712704c9df178d5df61d96062a11b22/test/e2e/ipv6.spec.ts

These tests are using `mockttp` with as target server.

I applied the fixes from this PR in this draft PR: https://github.com/chimurai/http-proxy-middleware/pull/1234

Looks like it fixes the issue.

For full transparency, I used Copilot to help with analysis and creating this PR and the description below.

---

### Summary
Fix IPv6 host serialization when reconstructing absolute request URLs from parsed destination data.

Mockttp already parses bracketed IPv6 Host headers correctly, but when rebuilding `host[:port]` strings it was dropping the brackets. For requests like Host: `[::1]:8000`, that produced invalid absolute URLs such as `http://::1:8000/api`, which fail URL parsing and trigger a `400` before request handlers run.

### Changes
- Update host normalization to re-add brackets when serializing IPv6 literal hostnames
- Preserve existing default-port behavior so `:80` for HTTP and `:443` for HTTPS are still omitted
- Leave parsing behavior unchanged for bracketed IPv6 input
- Add regression coverage for:
	- IPv6 normalization with non-default HTTP and HTTPS ports
	- IPv6 normalization with default ports
	- Request preprocessing from Host: `[::1]:8000`
	- Existing IPv4 and DNS host formatting behavior

### Example
Before:

Host: `[::1]:8000`
reconstructed URL: `http://::1:8000/api`
URL parsing fails, request returns `400`

After:

Host: `[::1]:8000`
reconstructed URL: `http://[::1]:8000/api`
request is processed normally