### PR TITLE
Add Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This adds a Dependabot configuration to keep npm and GitHub Actions dependencies up to date automatically.

**What it does:**
- Enables weekly Dependabot checks for both `npm` and `github-actions` ecosystems
- Groups all updates per ecosystem into a single PR to reduce noise

**Why:** The repo has no existing dependency update automation (no `dependabot.yml`, no Renovate config). Automated dependency updates reduce the maintenance burden and surface security patches promptly.

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.